### PR TITLE
upgrade to latest deploy method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Jenkinsfile build job added
 - Updated to shared pipeline library 0.6.1 and JDK 11
 - Upgrade various dependencies
+- Updated to latest build/deploy method
 
 [Unreleased]: https://github.com/ACWI-SSWD/nldi-crawler/compare/nldi-services-0.3.1...master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,109 +1,109 @@
-pipeline {
-  agent {
-    node {
-      label 'project:any'
-    }
-  }
-  parameters {
-    choice(choices: ['snapshots', 'releases'], description: 'type of build', name: 'BUILD_TYPE')
-    string(defaultValue: 'nldi', description: 'docker image path in artifactory', name: 'ARTIFACTORY_PATH', trim: false)
-    string(defaultValue: 'wma/docker/nldi', description: 'docker image path in gitlab', name: 'GITLAB_PATH', trim: false)
-    string(defaultValue: 'nldi-crawler', description: 'Name of the docker image', name: 'DOCKER_IMAGE_NAME', trim: false)
-  }
-  stages {
-    stage('prep virtualenv') {
-      steps {
-        sh'''/usr/bin/virtualenv $WORKSPACE/env
-        $WORKSPACE/env/bin/pip install bumpversion
-        '''
-      }
-    }
-    stage('Build and test Docker image') {
-      steps {
-        withCredentials([
-          string(credentialsId: 'ARTIFACTORY_HOST', variable: 'artifactoryHost'),
-          string(credentialsId: 'GITLAB_HOST', variable: 'gitlabHost'),
-          string(credentialsId: 'ECR_HOST', variable: 'ecrHost')
-          ]) {
-          sh '''
-          if [ $BUILD_TYPE == "releases" ]
-          then
-            bumpversion_resp=$($WORKSPACE/env/bin/bumpversion --allow-dirty --list release)
-            result=$(echo $bumpversion_resp | grep -oh 'new_version=.*')
-          else
-            bumpversion_resp=$($WORKSPACE/env/bin/bumpversion --allow-dirty --no-tag --no-commit --list minor)
-            result=$(echo $bumpversion_resp | grep -oh '^[^ ]*')
-            /usr/bin/git reset --hard HEAD
-          fi
-          timestamp=$(date +%s)
-          bumpversion=$(/usr/bin/cut -d'=' -f2 <<<$result)
-          version="${bumpversion}-${timestamp}"
-          echo "version=${version}" > version.properties
-          echo "${version}" > version.txt
-          '''
-          script {
-            contents = readFile 'version.txt'
-            def version = contents.trim()
-            def artifactoryPort
-            if ("${BUILD_TYPE}" == "releases") {
-              artifactoryPort = '8446'
-            } else {
-              artifactoryPort = '8445'
-            }
-            def dockerImage = docker.build(DOCKER_IMAGE_NAME)
-            sh "docker tag ${DOCKER_IMAGE_NAME} ${artifactoryHost}:${artifactoryPort}/${ARTIFACTORY_PATH}/${DOCKER_IMAGE_NAME}:${version}"
-            sh "docker tag ${DOCKER_IMAGE_NAME} ${gitlabHost}:5001/${GITLAB_PATH}/${DOCKER_IMAGE_NAME}:${version}"
-            sh "docker tag ${DOCKER_IMAGE_NAME} ${ecrHost}/${DOCKER_IMAGE_NAME}:${version}"
-            sh "docker tag ${DOCKER_IMAGE_NAME} ${ecrHost}/${DOCKER_IMAGE_NAME}:latest"
-            sh "docker tag ${DOCKER_IMAGE_NAME} usgswma/${DOCKER_IMAGE_NAME}:${version}"
-          }
-        }
-      }
-    }
-    stage('Publish Docker images') {
-      steps {
-        withCredentials([
-          string(credentialsId: 'ARTIFACTORY_HOST', variable: 'artifactoryHost'),
-          string(credentialsId: 'GITLAB_HOST', variable: 'gitlabHost'),
-          string(credentialsId: 'ECR_HOST', variable: 'ecrHost')
-          ]) {
-          script {
-            contents = readFile 'version.txt'
-            def version = contents.trim()
-            if ("${BUILD_TYPE}" == "releases") {
-              artifactoryPort = '8446'
-            } else {
-              artifactoryPort = '8445'
-            }
-            // Push to Artifactory
-            withDockerRegistry([credentialsId: 'ARTIFACTORY_UPLOADER_CREDENTIALS', url: "https://${artifactoryHost}:${artifactoryPort}"]) {
-              sh "docker push ${artifactoryHost}:${artifactoryPort}/${ARTIFACTORY_PATH}/${DOCKER_IMAGE_NAME}:${version}"
-            }
-            // Push to Gitlab
-            withDockerRegistry([credentialsId: 'jenkins_ci_access_token', url: 'https://${gitlabHost}:5001']) {
-              sh "docker push ${gitlabHost}:5001/${GITLAB_PATH}/${DOCKER_IMAGE_NAME}:${version}"
-            }
-            // Push to ECR
-            sh "#!/bin/sh -e\n" + "eval \$(aws --region us-west-2 ecr get-login --no-include-email)"
-            sh "docker push ${ecrHost}/${DOCKER_IMAGE_NAME}:${version}"
-            sh "docker push ${ecrHost}/${DOCKER_IMAGE_NAME}:latest"
-          }
-        }
-      }
-    }
-    stage('Push bumped version to git') {
-      steps {
-        withCredentials([string(credentialsId: 'GITHUB_ACCESS_TOKEN', variable: 'jenkinsToken')]) {
-          sh '''
-            if [ $BUILD_TYPE == "releases" ]
-            then
-              $WORKSPACE/env/bin/bumpversion --allow-dirty --no-tag minor
-              /usr/bin/git push
-              /usr/bin/git push --tags
-            fi
-          '''
-        }
-      }
-    }
-  }
-}
+//pipeline {
+//  agent {
+//    node {
+//      label 'project:any'
+//    }
+//  }
+//  parameters {
+//    choice(choices: ['snapshots', 'releases'], description: 'type of build', name: 'BUILD_TYPE')
+//    string(defaultValue: 'nldi', description: 'docker image path in artifactory', name: 'ARTIFACTORY_PATH', trim: false)
+//    string(defaultValue: 'wma/docker/nldi', description: 'docker image path in gitlab', name: 'GITLAB_PATH', trim: false)
+//    string(defaultValue: 'nldi-crawler', description: 'Name of the docker image', name: 'DOCKER_IMAGE_NAME', trim: false)
+//  }
+//  stages {
+//    stage('prep virtualenv') {
+//      steps {
+//        sh'''/usr/bin/virtualenv $WORKSPACE/env
+//        $WORKSPACE/env/bin/pip install bumpversion
+//        '''
+//      }
+//    }
+//    stage('Build and test Docker image') {
+//      steps {
+//        withCredentials([
+//          string(credentialsId: 'ARTIFACTORY_HOST', variable: 'artifactoryHost'),
+//          string(credentialsId: 'GITLAB_HOST', variable: 'gitlabHost'),
+//          string(credentialsId: 'ECR_HOST', variable: 'ecrHost')
+//          ]) {
+//          sh '''
+//          if [ $BUILD_TYPE == "releases" ]
+//          then
+//            bumpversion_resp=$($WORKSPACE/env/bin/bumpversion --allow-dirty --list release)
+//            result=$(echo $bumpversion_resp | grep -oh 'new_version=.*')
+//          else
+//            bumpversion_resp=$($WORKSPACE/env/bin/bumpversion --allow-dirty --no-tag --no-commit --list minor)
+//            result=$(echo $bumpversion_resp | grep -oh '^[^ ]*')
+//            /usr/bin/git reset --hard HEAD
+//          fi
+//          timestamp=$(date +%s)
+//          bumpversion=$(/usr/bin/cut -d'=' -f2 <<<$result)
+//          version="${bumpversion}-${timestamp}"
+//          echo "version=${version}" > version.properties
+//          echo "${version}" > version.txt
+//          '''
+//          script {
+//            contents = readFile 'version.txt'
+//            def version = contents.trim()
+//            def artifactoryPort
+//            if ("${BUILD_TYPE}" == "releases") {
+//              artifactoryPort = '8446'
+//            } else {
+//              artifactoryPort = '8445'
+//            }
+//            def dockerImage = docker.build(DOCKER_IMAGE_NAME)
+//            sh "docker tag ${DOCKER_IMAGE_NAME} ${artifactoryHost}:${artifactoryPort}/${ARTIFACTORY_PATH}/${DOCKER_IMAGE_NAME}:${version}"
+//            sh "docker tag ${DOCKER_IMAGE_NAME} ${gitlabHost}:5001/${GITLAB_PATH}/${DOCKER_IMAGE_NAME}:${version}"
+//            sh "docker tag ${DOCKER_IMAGE_NAME} ${ecrHost}/${DOCKER_IMAGE_NAME}:${version}"
+//            sh "docker tag ${DOCKER_IMAGE_NAME} ${ecrHost}/${DOCKER_IMAGE_NAME}:latest"
+//            sh "docker tag ${DOCKER_IMAGE_NAME} usgswma/${DOCKER_IMAGE_NAME}:${version}"
+//          }
+//        }
+//      }
+//    }
+//    stage('Publish Docker images') {
+//      steps {
+//        withCredentials([
+//          string(credentialsId: 'ARTIFACTORY_HOST', variable: 'artifactoryHost'),
+//          string(credentialsId: 'GITLAB_HOST', variable: 'gitlabHost'),
+//          string(credentialsId: 'ECR_HOST', variable: 'ecrHost')
+//          ]) {
+//          script {
+//            contents = readFile 'version.txt'
+//            def version = contents.trim()
+//            if ("${BUILD_TYPE}" == "releases") {
+//              artifactoryPort = '8446'
+//            } else {
+//              artifactoryPort = '8445'
+//            }
+//            // Push to Artifactory
+//            withDockerRegistry([credentialsId: 'ARTIFACTORY_UPLOADER_CREDENTIALS', url: "https://${artifactoryHost}:${artifactoryPort}"]) {
+//              sh "docker push ${artifactoryHost}:${artifactoryPort}/${ARTIFACTORY_PATH}/${DOCKER_IMAGE_NAME}:${version}"
+//            }
+//            // Push to Gitlab
+//            withDockerRegistry([credentialsId: 'jenkins_ci_access_token', url: 'https://${gitlabHost}:5001']) {
+//              sh "docker push ${gitlabHost}:5001/${GITLAB_PATH}/${DOCKER_IMAGE_NAME}:${version}"
+//            }
+//            // Push to ECR
+//            sh "#!/bin/sh -e\n" + "eval \$(aws --region us-west-2 ecr get-login --no-include-email)"
+//            sh "docker push ${ecrHost}/${DOCKER_IMAGE_NAME}:${version}"
+//            sh "docker push ${ecrHost}/${DOCKER_IMAGE_NAME}:latest"
+//          }
+//        }
+//      }
+//    }
+//    stage('Push bumped version to git') {
+//      steps {
+//        withCredentials([string(credentialsId: 'GITHUB_ACCESS_TOKEN', variable: 'jenkinsToken')]) {
+//          sh '''
+//            if [ $BUILD_TYPE == "releases" ]
+//            then
+//              $WORKSPACE/env/bin/bumpversion --allow-dirty --no-tag minor
+//              /usr/bin/git push
+//              /usr/bin/git push --tags
+//            fi
+//          '''
+//        }
+//      }
+//    }
+//  }
+//}

--- a/buildJenkinsfile
+++ b/buildJenkinsfile
@@ -1,9 +1,9 @@
-@Library(value='PipelineLibs@0.6.1', changelog=false) _
+@Library(value='iow-ecs-pipeline@2.2.0', changelog=false) _
 
 pipeline {
     agent {
         node {
-            label 'project:any'
+            label 'team:iow'
         }
     }
     parameters {

--- a/deployJenkinsfile
+++ b/deployJenkinsfile
@@ -1,4 +1,4 @@
-@Library(value='PipelineLibs@0.6.1', changelog=false) _
+@Library(value='iow-ecs-pipeline@2.2.0', changelog=false) _
 
 pipeline {
     agent {

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,16 +1,33 @@
-projectName: "nldi"
-applicationName: "nldi-crawler"
-dockerImageName: "nldi-crawler"
-containerPort: 8080
+# docker image path in artifactory
 artifactoryPath: "nldi"
-gitlabPath: "wma/docker/nldi"
+# docker image path in gitlab
+gitlabPath: "wma/docker/nldi/nldi-crawler"
+# name of the docker image
+dockerImageName: "nldi-crawler"
+#
+repoPath: "ACWI-SSWD/nldi-crawler.git"
+# name of the git repo
 gitRepoUrl: "https://github.com/ACWI-SSWD/nldi-crawler.git"
+# Jenkins credential for pushing back to repo
 gitRepoCredentialsId: "Jenkins-GitHub-Read-Write-Token"
+# name of the deploy job to trigger
+deployJobName: "ogcproxy-container-deploy"
+# name of the project
+projectName: "iow-allgemein"
+# maximum amount of RAM for running Docker containers in the service
 memory: 768
-rulePriority: 88
+# name of the application or service
+applicationName: "nldi-crawler"
+# integer representing the order of precedence of the ALB rule.
+# port that is exposed by your container
+containerPort: 8080
+# string parameter specifying a path that ALB should use to verify that your application is alive
 healthCheck: "/actuator/health"
-contextPath: "/nldi-crawler"
-#deployJobName: "ogcproxy-container-deploy"
+# configuration repository paths
+configRepoPath: "wma/docker/nldi/nldi-crawler"
+configCredentialsId: "wma-eto-eb-rsa"
+
+
 nldi:
   url: "jdbc:postgresql://127.0.0.1:5433/nldi"
   dbUsername: nldi_data
@@ -18,6 +35,10 @@ nldi:
   dbName: nldi
   dbPort: 5433
 
+rulePriority: 88
+contextPath: "/nldi-crawler"
 
+#This is the old gitlab path
+#gitlabPath: "wma/docker/nldi"
 #nldi.dbUnitPassword>nldi</nldi.dbUnitPassword>
 #nldi.dbPassword>nldi</nldi.dbPassword>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Update nldi-crawler to latest build/deploy
-----------
Right now nldi-crawler can be built successfully, but cannot be deployed.  It fails with an error that says the artifactory uploader credential can't be found.   As per Dave Steinich, nldi-crawler has not been upgraded to use the latest build/deploy mechanisms, and should be updated to resemble nldi-services in the area of jenkins files and pipeline.

Description
-----------
I have updated the nldi-crawler pipeline and jenkins files to resemble nldi-services.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
